### PR TITLE
修复硬编码个人路径，改用项目相对路径

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ daily-stock-analysis/scripts/holdings.json
 daily-stock-analysis/scripts/gui_settings.json
 daily-stock-analysis/scripts/.em_nontrading_refresh
 tools/shadow_data/shadow_samples.json
+
+# 本地个人运行数据（报告 / 决策记录 / 持仓），不应上传 GitHub
+筛选结果/
+决策记录/

--- a/daily-stock-analysis/codex_prompt.md
+++ b/daily-stock-analysis/codex_prompt.md
@@ -41,7 +41,7 @@ curl -s http://localhost:8765/api/md
 
 ## 数据源 2：MD 文件（看变化趋势）
 
-文件位置：`/Users/luqiang/Documents/Others/股票/筛选结果/`
+文件位置：项目根目录下的 `筛选结果/`
 
 ### 文件命名规则
 - 盘中：`A股筛选结果_YYYYMMDD_HHMM.md`（平铺在根目录）
@@ -50,7 +50,7 @@ curl -s http://localhost:8765/api/md
 ### 如何对比资金变化
 1. 列出最近几个文件：
 ```bash
-ls -t /Users/luqiang/Documents/Others/股票/筛选结果/A股筛选结果_*.md | head -5
+ls -t 筛选结果/A股筛选结果_*.md | head -5
 ```
 
 2. 读取最近 3~5 个文件，对比同一只股票的资金字段变化：

--- a/daily-stock-analysis/codex_prompt_simple.md
+++ b/daily-stock-analysis/codex_prompt_simple.md
@@ -13,7 +13,7 @@ curl -s http://localhost:8765/api/data
 
 **看资金变化趋势：** 读最近 3-5 个 MD 文件对比同一只股票的主力净额变化。
 ```bash
-ls -t /Users/luqiang/Documents/Others/股票/筛选结果/A股筛选结果_*.md | head -5
+ls -t 筛选结果/A股筛选结果_*.md | head -5
 ```
 
 如果 curl 失败，服务器没开，告诉大强运行 `运行实时看板.command`。

--- a/daily-stock-analysis/scripts/a_share_screen_gui.py
+++ b/daily-stock-analysis/scripts/a_share_screen_gui.py
@@ -20,7 +20,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 SCREEN_SCRIPT = SCRIPT_DIR / "a_share_daily_screen.py"
 HOLDINGS_FILE = SCRIPT_DIR / "holdings.json"
 SETTINGS_FILE = SCRIPT_DIR / "gui_settings.json"
-OUTPUT_DIR = Path("/Users/luqiang/Documents/Others/股票/筛选结果")
+OUTPUT_DIR = SCRIPT_DIR.parent.parent / "筛选结果"
 
 
 def default_output_path() -> Path:

--- a/daily-stock-analysis/scripts/realtime_dashboard.py
+++ b/daily-stock-analysis/scripts/realtime_dashboard.py
@@ -198,7 +198,7 @@ SCREENING_TIMEOUT = 120
 # 代理断开时，用更短的轮询间隔探测恢复（正常刷新间隔是 settings["interval"]=90s）。
 # 你一旦把代理弄通，看板约 20s 内自动恢复，不用干等一整轮。
 PROXY_RECOVERY_INTERVAL = 15
-MD_OUTPUT_DIR = Path("/Users/luqiang/Documents/Others/股票/筛选结果")
+MD_OUTPUT_DIR = SCRIPT_DIR.parent.parent / "筛选结果"
 # 持久化最近一次「有效完整」结果，供非交易时段保留快照 / 跨重启恢复
 LAST_VALID_RESULT_PATH = SCRIPT_DIR / "last_valid_result.json"
 

--- a/daily-stock-analysis/运行实时看板.command
+++ b/daily-stock-analysis/运行实时看板.command
@@ -4,9 +4,12 @@
 
 cd "$(dirname "$0")"
 
-PYTHON="/Users/luqiang/.workbuddy/binaries/python/versions/3.13.12/bin/python3"
-if [ ! -f "$PYTHON" ]; then
-    PYTHON="$(which python3)"
+# 优先使用 PATH 中的 python3（README 要求 Python 3.10+）
+PYTHON="$(command -v python3)"
+if [ -z "$PYTHON" ]; then
+    echo "未找到 python3，请先安装 Python 3.10 或更高版本"
+    read -p "按回车退出..."
+    exit 1
 fi
 
 # 东财数据必须走代理(直连被封)。这里只检测并打印系统代理，**不固化到环境变量**，

--- a/sync_to_github.sh
+++ b/sync_to_github.sh
@@ -3,7 +3,8 @@
 # 由 LaunchAgent com.luqiang.syncstock 每 5 分钟触发一次
 # 无变更时零操作退出；有变更才 commit + push
 
-REPO="/Users/luqiang/Documents/Others/股票"
+# 仓库根目录 = 本脚本所在目录，不再写死个人路径
+REPO="$(cd "$(dirname "$0")" && pwd)"
 LOG="$HOME/Library/Logs/sync_to_github.log"
 
 cd "$REPO" || exit 1


### PR DESCRIPTION
## 问题

README「已知问题」第 1 条：部分代码仍使用作者本机固定路径（`/Users/luqiang/Documents/Others/股票/...`），其他人克隆后：

- 实时看板保存 Markdown 报告报 `Permission denied`，`/api/md` 无内容
- GUI 无法保存筛选结果
- 启动器和同步脚本依赖作者本机路径

## 修改内容

| 文件 | 修改 |
| --- | --- |
| `scripts/a_share_screen_gui.py` | 输出目录改为 `项目根目录/筛选结果`（动态推导） |
| `scripts/realtime_dashboard.py` | Markdown 保存目录同上，与 `tools/` 下各工具既有的相对路径约定一致 |
| `运行实时看板.command` | 移除作者本机 Python 绝对路径，改用 PATH 中的 `python3`，找不到时明确提示 |
| `sync_to_github.sh` | `REPO` 改为脚本所在目录自动推导 |
| `codex_prompt.md` / `codex_prompt_simple.md` | 文档示例路径改为相对路径 |
| `.gitignore` | 增加 `筛选结果/`、`决策记录/`，避免本地报告和个人数据被误提交 |

## 验证

- `py_compile` 全部通过；`python3 -m unittest discover` 76 个测试通过
- 实机运行看板验证：报告成功保存到 `项目根目录/筛选结果/A股筛选结果_YYYYMMDD_HHMM.md`，`/api/md` 恢复正常
- 未包含任何本地运行数据（报告、日志、缓存均已排除）