### PR TITLE
fix: 修复硬编码个人路径，改用项目相对路径（含 README 代理说明纠正）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ daily-stock-analysis/scripts/holdings.json
 daily-stock-analysis/scripts/gui_settings.json
 daily-stock-analysis/scripts/.em_nontrading_refresh
 tools/shadow_data/shadow_samples.json
+
+# Personal reports & decision logs (see README section 4: never upload)
+筛选结果/
+决策记录/

--- a/README.md
+++ b/README.md
@@ -286,8 +286,8 @@ python3 -m unittest discover -s daily-stock-analysis/scripts -p 'test_*.py'
 
 以下问题已知存在，后续需要通过 Agent 修改代码或启动配置解决：
 
-1. **筛选结果保存路径**：部分 GUI 和实时看板代码仍使用本机固定路径。后续应改为基于项目根目录的相对路径，或提供可配置的输出目录，方便其他使用者直接运行。
-2. **网络代理依赖 Clash Verge**：当前运行环境需要通过 Clash Verge 的系统代理访问行情接口，直连行情服务会被封锁。使用实时筛选或看板前，应确认 Clash Verge 已启动并开启系统代理；命令行可使用 `--network-mode proxy`。
+1. **筛选结果保存路径（已在本 PR 修复）**：部分 GUI 和实时看板代码曾使用本机固定路径（`/Users/luqiang/...`），其他使用者克隆后会因无权限创建目录导致保存报告失败。现改为基于项目根目录动态推导（`项目根/筛选结果`），并支持通过环境变量 `BIG_A_CHOVY_OUTPUT_DIR` 覆盖输出目录。
+2. **部分网络环境需要系统代理**：作者的开发环境中需通过 Clash Verge 的系统代理访问行情接口。该限制与具体网络环境有关，并非普遍情况：已实测国内部分网络下 `--network-mode direct` 可直连行情接口正常筛选（全市场扫描约 20 秒完成）。建议遇到连接问题时先尝试 `--network-mode direct`，不通再开启系统代理使用 `--network-mode proxy`。
 
 ## 十、内置 Skill
 

--- a/daily-stock-analysis/scripts/a_share_screen_gui.py
+++ b/daily-stock-analysis/scripts/a_share_screen_gui.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import queue
 import re
 import subprocess
@@ -17,10 +18,15 @@ from a_share_daily_screen import build_url_opener, NETWORK_MODE
 
 
 SCRIPT_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = SCRIPT_DIR.parent.parent
 SCREEN_SCRIPT = SCRIPT_DIR / "a_share_daily_screen.py"
 HOLDINGS_FILE = SCRIPT_DIR / "holdings.json"
 SETTINGS_FILE = SCRIPT_DIR / "gui_settings.json"
-OUTPUT_DIR = Path("/Users/luqiang/Documents/Others/股票/筛选结果")
+# 输出目录基于项目根目录解析，可通过环境变量 BIG_A_CHOVY_OUTPUT_DIR 覆盖。
+OUTPUT_DIR = Path(
+    os.environ.get("BIG_A_CHOVY_OUTPUT_DIR")
+    or (PROJECT_ROOT / "筛选结果")
+).expanduser()
 
 
 def default_output_path() -> Path:

--- a/daily-stock-analysis/scripts/realtime_dashboard.py
+++ b/daily-stock-analysis/scripts/realtime_dashboard.py
@@ -198,7 +198,12 @@ SCREENING_TIMEOUT = 120
 # 代理断开时，用更短的轮询间隔探测恢复（正常刷新间隔是 settings["interval"]=90s）。
 # 你一旦把代理弄通，看板约 20s 内自动恢复，不用干等一整轮。
 PROXY_RECOVERY_INTERVAL = 15
-MD_OUTPUT_DIR = Path("/Users/luqiang/Documents/Others/股票/筛选结果")
+# 输出目录基于项目根目录解析，可通过环境变量 BIG_A_CHOVY_OUTPUT_DIR 覆盖。
+# 与 a_share_screen_gui.py 保持同一环境变量，避免两处输出落到不同位置。
+MD_OUTPUT_DIR = Path(
+    os.environ.get("BIG_A_CHOVY_OUTPUT_DIR")
+    or (SCRIPT_DIR.parent.parent / "筛选结果")
+).expanduser()
 # 持久化最近一次「有效完整」结果，供非交易时段保留快照 / 跨重启恢复
 LAST_VALID_RESULT_PATH = SCRIPT_DIR / "last_valid_result.json"
 


### PR DESCRIPTION
## 背景

README「已知问题」第 1 条 + issue #1：部分代码使用作者本机固定路径（`/Users/luqiang/Documents/Others/股票/...`），其他使用者克隆后 GUI 保存报告和实时看板写报告会因无权限报错，`/api/md` 永远为空。

## 改动

| 文件 | 修改 |
| --- | --- |
| `daily-stock-analysis/scripts/a_share_screen_gui.py` | 输出目录改为基于项目根动态推导（项目根/筛选结果），支持环境变量 `BIG_A_CHOVY_OUTPUT_DIR` 覆盖 |
| `daily-stock-analysis/scripts/realtime_dashboard.py` | 同上，两处共用同一环境变量 |
| `.gitignore` | 补上 `筛选结果/`、`决策记录/`（README 第四章声明不上传，但 gitignore 缺失，会误提交个人数据） |
| `README.md` | 已知问题第 1 条标记为已修复；第 2 条从「直连行情服务会被封锁」改为「部分网络环境需要系统代理」，注明实测部分网络直连可正常筛选 |

## 验证

- `py_compile` 通过，76 个单元测试全部通过
- 实机保存报告成功写入项目根/筛选结果，看板 `/api/md` 正常返回
- 未包含任何本地运行数据

Refs: issue #1